### PR TITLE
Devops: change OTEL agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,18 @@ RUN mvn clean install -U -s settings.xml && \
     mvn package -Dmaven.test.skip=true -s settings.xml
 
 FROM openjdk:23-jdk-slim
+ARG GRAFANA_OTEL_VERSION=v2.15.0
+ENV GRAFANA_OTEL_JAR=grafana-opentelemetry-java-${GRAFANA_OTEL_VERSION}.jar
+
 WORKDIR /app
 COPY --from=builder /app/target/*.jar app.jar
-COPY integration/grafana-opentelemetry-java-v2.15.0.jar ./grafana-opentelemetry-java-v2.15.0.jar
 
-CMD ["java", "-Xms128m", "-Xmx1024m", "-javaagent:grafana-opentelemetry-java-v2.15.0.jar", "-jar", "app.jar"]
+# Install curl, download the agent and clean up
+RUN apt-get update && \
+    apt-get install -y curl && \
+    curl -s -L https://github.com/grafana/grafana-opentelemetry-java/releases/download/${GRAFANA_OTEL_VERSION}/grafana-opentelemetry-java.jar \
+     -o ${GRAFANA_OTEL_JAR} && \
+    apt-get purge -y --auto-remove curl && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["sh", "-c", "java -Xms128m -Xmx1024m -javaagent:${GRAFANA_OTEL_JAR} -jar app.jar"]


### PR DESCRIPTION
Please pull these awesome changes in!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved Docker image flexibility by allowing dynamic selection and download of the Grafana OpenTelemetry Java agent version during build.
	- Reduced image size by installing and removing build dependencies as needed.
	- Startup command now automatically uses the specified agent version without manual updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->